### PR TITLE
Make Clustering non-lazy dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,10 @@ version = "0.1.1"
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
-LazyModules = "8cdb02fc-e678-4876-92c5-9defec4f444e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Clustering = "0.14.3, 0.15"
 Colors = "0.12"
 ImageBase = "0.1"
-LazyModules = "0.3"
 julia = "1.6"

--- a/src/ColorQuantization.jl
+++ b/src/ColorQuantization.jl
@@ -4,17 +4,14 @@ using Colors
 using ImageBase: FixedPoint, floattype, FixedPointNumbers.rawtype
 using ImageBase: channelview, colorview, restrict
 using Random: AbstractRNG, GLOBAL_RNG
-using LazyModules: @lazy
-#! format: off
-@lazy import Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
-#! format: on
+using Clustering: kmeans, _kmeans_default_init, _kmeans_default_maxiter, _kmeans_default_tol
 
 abstract type AbstractColorQuantizer end
 
 include("api.jl")
 include("utils.jl")
 include("uniform.jl")
-include("clustering.jl") # lazily loaded
+include("clustering.jl")
 
 export AbstractColorQuantizer, quantize
 export UniformQuantization, KMeansQuantization

--- a/src/clustering.jl
+++ b/src/clustering.jl
@@ -1,11 +1,4 @@
-# The following code is lazily loaded from Clustering.jl using LazyModules.jl
 # Code adapted from @cormullion's ColorSchemeTools (https://github.com/JuliaGraphics/ColorSchemeTools.jl)
-
-# The following type definition is taken from from Clustering.jl for the kwarg `init`:
-const ClusteringInitType = Union{
-    Symbol,Clustering.SeedingAlgorithm,AbstractVector{<:Integer}
-}
-
 const KMEANS_DEFAULT_COLORSPACE = RGB{Float32}
 
 """
@@ -28,8 +21,7 @@ The default values are carried over from are imported from Clustering.jl.
 For more details, refer to the [documentation](https://juliastats.org/Clustering.jl/stable/)
 of Clustering.jl.
 """
-struct KMeansQuantization{T<:Colorant,I<:ClusteringInitType,R<:AbstractRNG} <:
-       AbstractColorQuantizer
+struct KMeansQuantization{T<:Colorant,I,R<:AbstractRNG} <: AbstractColorQuantizer
     ncolors::Int
     maxiter::Int
     tol::Float64
@@ -39,9 +31,9 @@ struct KMeansQuantization{T<:Colorant,I<:ClusteringInitType,R<:AbstractRNG} <:
     function KMeansQuantization(
         T::Type{<:Colorant},
         ncolors::Integer;
-        init=Clustering._kmeans_default_init,
-        maxiter=Clustering._kmeans_default_maxiter,
-        tol=Clustering._kmeans_default_tol,
+        init=_kmeans_default_init,
+        maxiter=_kmeans_default_maxiter,
+        tol=_kmeans_default_tol,
         rng=GLOBAL_RNG,
     )
         ncolors ≥ 2 ||
@@ -62,7 +54,7 @@ end
 
 function _kmeans(alg::KMeansQuantization, cs::AbstractArray{<:Colorant{T,N}}) where {T,N}
     data = reshape(channelview(cs), N, :)
-    R = Clustering.kmeans(
+    R = kmeans(
         data, alg.ncolors; maxiter=alg.maxiter, tol=alg.tol, init=alg.init, rng=alg.rng
     )
     return colorview(eltype(cs), R.centers)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,11 +25,11 @@ algs_deterministic = Dict(
     @testset "Reference tests" begin
         for (name, alg) in algs_deterministic
             @testset "$name" begin
-                cs = quantize(img, alg)
+                cs = @inferred quantize(img, alg)
                 @test eltype(cs) == eltype(img)
                 @test_reference "references/$(name).txt" cs
 
-                cs = quantize(HSV{Float16}, img, alg)
+                cs = @inferred quantize(HSV{Float16}, img, alg)
                 @test eltype(cs) == HSV{Float16}
                 @test_reference "references/$(name)_HSV.txt" cs
             end
@@ -41,14 +41,14 @@ algs_deterministic = Dict(
         c3 = RGB(0.11, 0.52, 0.73)
         cs = [c1, c2, c3]
 
-        cs1 = quantize(cs, UniformQuantization(2))
+        cs1 = @inferred quantize(cs, UniformQuantization(2))
         # Centers of cubes at: 0.25, 0.75
         # c1 and c2 get quantized to the same color
         @test length(cs1) == 2
         @test cs1[1] == RGB(0.25, 0.25, 0.75)
         @test cs1[2] == RGB(0.25, 0.75, 0.75)
 
-        cs2 = quantize(cs, UniformQuantization(4))
+        cs2 = @inferred quantize(cs, UniformQuantization(4))
         # Centers of cubes at: 0.125, 0.375, 0.625, 0.875
 
         # Remember that `round` defaults to `RoundNearest`,
@@ -58,7 +58,10 @@ algs_deterministic = Dict(
         @test cs2[2] == RGB(0.375, 0.625, 0.625)
         @test cs2[3] == RGB(0.125, 0.625, 0.625)
     end
-
+    @testset "Type stability" begin
+        # @inferred UniformQuantization(4) # runtime inferrence due to {N} = 4
+        @inferred KMeansQuantization(8)
+    end
     @testset "Error messages" begin
         @test_throws ArgumentError UniformQuantization(0)
         @test_throws ArgumentError KMeansQuantization(0)


### PR DESCRIPTION
Fixes type inference problems with `KMeansQuantization`.